### PR TITLE
PSG-4483: fixes CVEs for openssl, curl, and busybox

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
 FROM nginx:stable-alpine
-RUN apk --no-cache add 'openssl>=3.0.12-r4'
+RUN apk --no-cache add 'openssl>=3.0.14-r0'
 RUN apk --no-cache add 'expat>=2.6.2-r0'
+RUN apk --no-cache add 'curl>=8.9.0-r0'
+RUN apk --no-cache add 'busybox>=1.35.0-r31'
 COPY nginx.conf /etc/nginx/nginx.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 FROM nginx:stable-alpine
-RUN apk --no-cache add 'openssl>=3.0.14-r0'
-RUN apk --no-cache add 'expat>=2.6.2-r0'
-RUN apk --no-cache add 'curl>=8.9.0-r0'
-RUN apk --no-cache add 'busybox>=1.35.0-r31'
+
+RUN apk --no-cache add \
+  'openssl>=3.0.14-r0' \
+  'expat>=2.6.2-r0' \
+  'curl>=8.9.0-r0' \
+  'busybox>=1.35.0-r31'
+
 COPY nginx.conf /etc/nginx/nginx.conf


### PR DESCRIPTION
CVEs [before](https://console.cloud.google.com/gcr/images/passage-prod/global/mixpanel-tracking-proxy@sha256:579ee8008f2235e9ba3e5470626525f208be93d94dd19f53775d4fd271cfdbf9/details?authuser=1&project=passage-prod&tab=vulnz)

CVEs [after](https://console.cloud.google.com/gcr/images/passage-prod/global/mixpanel-tracking-proxy@sha256:48d56a27a2ca9ff3ecf075f4ccc8ca72c7245924efde0ebcad7c39d09d90fddb/details?authuser=1&project=passage-prod&tab=vulnz)