### PR TITLE
PSG-5159: fix expat CVE

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM nginx:stable-alpine
 
 RUN apk --no-cache add \
   'openssl>=3.0.14-r0' \
-  'expat>=2.6.2-r0' \
+  'expat>=2.6.3-r0' \
   'curl>=8.9.0-r0' \
   'busybox>=1.35.0-r31'
 


### PR DESCRIPTION
Updates `expat` package to recommended fix version to address CVEs.

[Old image CVEs](https://console.cloud.google.com/gcr/images/passage-prod/global/mixpanel-tracking-proxy@sha256:48d56a27a2ca9ff3ecf075f4ccc8ca72c7245924efde0ebcad7c39d09d90fddb/details?authuser=1&project=passage-prod&supportedpurview=project&tab=vulnz)
[New image CVEs](https://console.cloud.google.com/gcr/images/passage-prod/global/mixpanel-tracking-proxy@sha256:2c91c22a574256488c7aea3b14fd1cde6c23ade4ed4ee3b1668c87b857afb3e2/details?authuser=1&project=passage-prod&supportedpurview=project&tab=vulnz)

![image](https://github.com/user-attachments/assets/360b6128-cc48-43d5-b82f-657236ab2216)
